### PR TITLE
Document the "strict" option

### DIFF
--- a/source/docs/sync-config.md
+++ b/source/docs/sync-config.md
@@ -35,6 +35,7 @@ The following methods are listed in alphabetical order.
 [.preface(icon, slogan)](#preface)
 [.registerFactory(name, factory)](#registerFactory)
 [.showHelpByDefault(boolean)](#showHelpByDefault)
+[.strict(boolean)](#strict)
 [.string(flags, opts)](#string)
 [.stringArray(flags, opts)](#stringArray)
 [.style(hooks)](#style)
@@ -1140,6 +1141,46 @@ Example:
 ```js
 sywac.showHelpByDefault()
 ```
+
+<a name="strict"></a>
+## `.strict(boolean)`
+
+<sup>Since 1.3.0</sup>
+
+In `strict` mode, unrecognized flags and positional arguments will generate an error.
+
+- &nbsp;`boolean`: boolean, default `true`
+
+  Whether to enable the mode or not.
+
+  Any value other than `false` (including no value) will enable the mode.
+
+Returns the `Api` instance for method chaining.
+
+Example:
+
+```js
+sywac.strict()
+```
+
+> Tip:
+>
+> Default commands are considered unrecognized arguments, so if your program has a default command make sure to disable strict mode for that command.
+>
+> Example:
+>
+> ```js
+> sywac
+>   .strict()
+>   .command('start', { run: () => console.log('start') })
+>   .command('stop', { run: () => console.log('stop') })
+>   .command('*', {
+>     setup: sywac => {
+>       sywac.strict(false)
+>     },
+>     run: () => console.log('default')
+>   })
+> ```
 
 <a name="string"></a>
 ## `.string(flags, opts)`

--- a/source/docs/type-properties.md
+++ b/source/docs/type-properties.md
@@ -8,8 +8,7 @@ next: /docs/boolean-type.html
 <a name="desc">
 ## desc / description
 
-The `desc` (or `description`) property controls the text displayed immediately to the
-right of the option or argument in the generated help text.
+The `desc` (or `description`) property controls the text displayed immediately to the right of the option or argument in the generated help text.
 
 If not specified, the description will be blank.
 
@@ -28,10 +27,7 @@ See also the [hints](#hints) property.
 <a name="group">
 ## group
 
-The `group` option allows you to organize options into multiple sections in the generated
-help text. By default, commands are grouped under the section `Commands:`, positional
-arguments are grouped under the section `Arguments:`, and flagged options are grouped
-under `Options:`.
+The `group` option allows you to organize options into multiple sections in the generated help text. By default, commands are grouped under the section `Commands:`, positional arguments are grouped under the section `Arguments:`, and flagged options are grouped under `Options:`.
 
 > Tip:
 >
@@ -64,8 +60,7 @@ sywac.boolean('--fancy', {
 });
 ```
 
-You can also use it to slurp up extra positional arguments, without being displayed in the
-arguments section.
+You can also use it to slurp up extra positional arguments, without being displayed in the arguments section.
 
 ```js
 sywac.positional('[users...]', {
@@ -76,14 +71,11 @@ sywac.positional('[users...]', {
 <a name="hints">
 ## hints
 
-The `hints` property controls the type information displayed to the far right of the
-option or argument in the generated help text.
+The `hints` property controls the type information displayed to the far right of the option or argument in the generated help text.
 
-By default, a hint will be generated automatically based on the type of the option -
-for example, `[boolean]` or `[number]`.
+By default, a hint will be generated automatically based on the type of the option - for example, `[boolean]` or `[number]`.
 
-You can use this to display an optional option as if it was required, or to make the
-hint more specific.
+You can use this to display an optional option as if it was required, or to make the hint more specific.
 
 ```js
 sywac.string('--name <name>', {


### PR DESCRIPTION
### SUMMARY

Document the "strict" option added in 1.3.0. Fixes #2.

### DETAILS

- Add section to the sync config page.
  - Includes a note about the current behavior of the interaction between default commands and strict mode - this note can be changed later if we fix/improve this behavior.
- Fix up the formatting of a previously added page.