### PR TITLE
Improve anchor chain behavior

### DIFF
--- a/themes/custom/layout/_partial/footer.ejs
+++ b/themes/custom/layout/_partial/footer.ejs
@@ -4,3 +4,7 @@
   <% } %>
   <span>Made with ♡ by <a href="https://github.com/nexdrew">nexdrew</a></span>
 </footer>
+<script src="/js/sywac.js"></script>
+<script>
+  SywacDocs.init()
+</script>

--- a/themes/custom/source/js/sywac.js
+++ b/themes/custom/source/js/sywac.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 window.SywacDocs = {
   scrollTarget() {
@@ -9,7 +9,7 @@ window.SywacDocs = {
     }
   },
   init() {
-    window.addEventListener('load', window.SywacDocs.scrollTarget);
-    window.addEventListener('hashchange', window.SywacDocs.scrollTarget);
+    window.addEventListener('load', window.SywacDocs.scrollTarget)
+    window.addEventListener('hashchange', window.SywacDocs.scrollTarget)
   }
 }

--- a/themes/custom/source/js/sywac.js
+++ b/themes/custom/source/js/sywac.js
@@ -1,0 +1,15 @@
+'use strict';
+
+window.SywacDocs = {
+  scrollTarget() {
+    const target = document.querySelector(':target')
+    if (target) {
+      document.querySelector('body').scrollTo(0, target.offsetTop - 64)
+      document.querySelector('html').scrollTo(0, target.offsetTop - 64)
+    }
+  },
+  init() {
+    window.addEventListener('load', window.SywacDocs.scrollTarget);
+    window.addEventListener('hashchange', window.SywacDocs.scrollTarget);
+  }
+}


### PR DESCRIPTION
### SUMMARY

When following an external direct link, or clicking on an anchor link on the same page, the browser's default behavior ends up hiding the header text underneath the header navbar.  Ensuring there's an extra 64px buffer above the header gives a better user experience.

### DETAILS

- Add a basic js file to the theme and load it in the footer.
- Initialize by setting up a load/hashchange event to find the `:target` and scroll up an extra 64px.
