### PR TITLE
[docs] Document String, Array

### DIFF
--- a/source/docs/array-type.md
+++ b/source/docs/array-type.md
@@ -119,4 +119,8 @@ sywac
 $ my-app April,Steve fruits,veggies
 Welcome April, Steve!
 I like to eat fruits, veggies!
+
+$ my-app April Steve fruits veggies
+Welcome April, Steve, fruits!
+I like to eat veggies!
 ```

--- a/source/docs/array-type.md
+++ b/source/docs/array-type.md
@@ -5,6 +5,118 @@ next: /docs/unknown-type.html
 ---
 # Array
 
-> No content yet
->
-> Sorry! This site is still under construction. Please bear with us until we can fill out more documentation. Thank you!
+The `Array` type represents a list of values. The values in an array can be of any other type supported by Sywac.
+
+## Properties
+
+In addition to [common type properties](/docs/type-properties.html), arrays also support:
+
+  - &nbsp;`delimiter` or `delim`: string or RegExp, default `','`
+
+    A delimiter used to split a single value into multiple values during parsing.
+
+    For example, parsing `-a one,two` would add values `'one'` and `'two'` to the array instead of `'one,two'`.
+
+  - &nbsp;`cumulative`: boolean, default `true`
+
+    If a flag is given multiple times, should the array value include all values from all flags (default) or only use the value(s) from the last flag given?
+
+    For example, parsing `-a one two -a three four` in cumulative mode would result in an array value of `['one', 'two', 'three', 'four']`. If you turn this off, the result would be only `['three', 'four']`.
+
+## Examples
+
+Use the [.array](/docs/sync-config.html#array) method to add a flagged option for an array of strings.
+
+```js
+sywac
+  .array('--people', { desc: 'specify a list of people' })
+  .parseAndExit().then(argv => {
+    console.log(`Welcome ${argv.people.join(', ')}!`)
+  })
+```
+```console
+$ my-app --people Anna George Stefan
+Welcome Anna, George, Stefan!
+```
+<br>
+
+The default value for an `Array` is `[]`.
+
+```console
+$ my-app
+Welcome !
+```
+<br>
+
+The [.stringArray](/docs/sync-config.html#stringArray) method is a more explicit alias for `.array`.
+
+```js
+sywac
+  .stringArray('--people', { desc: 'specify a list of people' })
+```
+<br>
+
+Use the [.numberArray](/docs/sync-config.html#numberArray) method to add a flagged option for an array of numbers.
+
+```js
+sywac
+  .numberArray('--max <numbers...>', { desc: 'specify a list of numbers' })
+  .parseAndExit().then(argv => {
+    console.log(Math.max(argv.max))
+  })
+```
+```console
+$ my-app 5 19 2
+19
+```
+<br>
+
+To define an array of any other type, use the [.option](/docs/sync-config.html#option) method and specifying the array type. The properties of your array can include properties supported by the array type. (For example, if you specify a type of `array:file`, you can also add properties related to the `File` type.)
+
+```js
+sywac
+  .option('--f <files...>', { type: 'array:file', mustExist: true })
+  .parseAndExit()
+```
+```console
+$ my-app -f file1 file2
+Usage: my-app [options]
+
+Options:
+  --f <files...>                                                           [array:file] [must exist]
+
+The file does not exist: file1
+The file does not exist: file2
+```
+<br>
+
+Use the [.positional](/docs/sync-config.html#positional) method to define a positional argument array.
+
+```js
+sywac
+  .positional('<names...>')
+  .parseAndExit().then(argv => {
+    console.log(`Welcome ${argv.names.join(', ')}!`)
+  })
+```
+```console
+$ my-app April Steve Jo
+Welcome April, Steve, Jo!
+```
+<br>
+
+When parsing positional arguments, an array type will do its best to leave enough arguments to satisfy other defined arguments. If the arguments are ambiguous (such as multiple arrays in a row), your users should use a value with delimiters instead of spaces.
+
+```js
+sywac
+  .positional('<names...> <foods...>')
+  .parseAndExit().then(argv => {
+    console.log(`Welcome ${argv.names.join(', ')}!`)
+    console.log(`I like to eat ${argv.foods.join(', ')}!`)
+  })
+```
+```console
+$ my-app April,Steve fruits,veggies
+Welcome April, Steve!
+I like to eat fruits, veggies!
+```

--- a/source/docs/string-type.md
+++ b/source/docs/string-type.md
@@ -5,6 +5,57 @@ next: /docs/path-type.html
 ---
 # String
 
-> No content yet
+The `String` type represents any user-entered value.
+
+## Properties
+
+`String` options and arguments support any of the [common type properties](/docs/type-properties.html).
+
+## Examples
+
+Use the [.string](/docs/sync-config.html#string) method to add a flagged option.
+
+```js
+sywac
+  .string('-n, --name <name>', { desc: 'specify your name' })
+  .parseAndExit().then(argv => {
+    console.log(`Hello, ${argv.name}!`)
+  })
+```
+```console
+$ my-app -n Jan
+Hello, Jan!
+```
+<br>
+
+The default value of a `String` is `undefined`.
+
+```console
+$ my-app
+Hello, undefined!
+```
+<br>
+
+Use the [.positional](/docs/sync-config.html#positional) method to add a positional argument.
+
+```js
+sywac
+  .positional('<name:string>')
+  .parseAndExit().then(argv => {
+    console.log(`Hello, ${argv.name}!`)
+  })
+```
+```console
+$ my-app Jan
+Hello, Jan!
+```
+<br>
+
+> Tip:
 >
-> Sorry! This site is still under construction. Please bear with us until we can fill out more documentation. Thank you!
+> You don't need to specify `:string`, because it is the default type for arguments.
+
+```js
+sywac.positional('<name>')
+```
+<br>


### PR DESCRIPTION
### SUMMARY

Take an initial stab at documenting Types.  I've chosen the simplest (String) and a relatively complex one (Array) to put my approach through its paces.

### DETAILS

- For `Types` documentation, my opinion is that we should avoid re-documenting the synchronous config methods.  For example, the `Array` type should not document the `.stringArray` method, but instead describe "how Arrays work" (how they parse, what the default values are, oddities or potential pitfalls when working with Arrays, etc.).

- Where possible, I think we should document through examples rather than paragraphs of text.  For Types I've attempted to include actual working program snippets, because (when we get into the more complex types) it's useful to see actual working error output and/or default value behavior.

- My current take is that a Type doc is: a summary, a list of supported properties above and beyond common type properties (this is re-doc from Sync Config), and then a series of examples that document everything else about a Type, for both flagged option and positional varieties.

- Low-key I am attempting to follow Microsoft's [brand voice](https://docs.microsoft.com/en-us/style-guide/top-10-tips-style-voice) (short, direct, but friendly).  Appreciate any feedback pointing out where I'm not, or if you prefer an alternate voice.

### NEXT STEPS

Things I'm still noodling on:

- Are "flagged options" and "positional arguments" different enough that I should include Examples for each as section headers, instead of just including them both in a list?

- Do we need Examples of the usage of every property supported by a type?

- Now that I'm looking over this PR, I see I'm "shortcutting" running examples in some cases (i.e., I'll make a comment and then just include a `console` snippet, assuming the `js` snippet hasn't changed).  This makes sense if you're reading a textbook but isn't optimized for scanning to what you're looking for and reading it, so even though it's kind of painful, maybe we should force every single example to be a js+console pair.

